### PR TITLE
fix: GitHub ActionsワークフローにGHCRアクセス権限を追加

### DIFF
--- a/.github/workflows/docker-build-manual.yml
+++ b/.github/workflows/docker-build-manual.yml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: yosuga-bot
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: checkout
         uses: actions/checkout@v5

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: yosuga-bot
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## 概要
このPRでは、GitHub ActionsワークフローにGitHub Container Registry（GHCR）へのアクセスに必要な権限を追加しました。

## 🔧 変更内容

### 権限の追加
- **`permissions`セクションを追加**：
  - `contents: read` - リポジトリコンテンツの読み取り権限
  - `packages: write` - GitHub Container Registryへのパッケージ書き込み権限

### 対象ファイル
- `.github/workflows/docker-build.yml` (masterブランチへのpush時のビルド)
- `.github/workflows/docker-build-manual.yml` (手動実行によるビルド)

## 🎯 問題の解決
GitHub Container Registryへのpushを行うワークフローには、明示的に`packages: write`権限が必要です。以前のワークフローでは権限が不足していたため、Dockerイメージのpushが失敗する可能性がありました。

## 📋 期待される効果
- GitHub Container Registryへの確実なDockerイメージpush
- ワークフローの実行エラーの解消
- セキュリティベストプラクティスに準拠した明示的な権限設定

## ⚠️ 注意事項
この変更により、ワークフローが必要最小限の権限のみを持つようになります。`GITHUB_TOKEN`のデフォルト権限に依存せず、明示的に権限を定義することでセキュリティが向上します。